### PR TITLE
Refine validation permissions and workflow for weekly timesheets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,4 @@
+{
+  "name": "mapiolca/timesheetweek",
+  "require": {}
+}

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -40,3 +40,13 @@ MyPageName = My page name
 #
 MyWidget = My widget
 MyWidgetDescription = My widget description
+
+#
+# Errors & status changes
+#
+BadStatusForSubmit = This timesheet cannot be submitted from its current status.
+NoLineToSubmit = No lines to submit on this timesheet.
+RefGenerationFailed = Unable to generate a definitive reference for the timesheet.
+BadStatusForApprove = Only submitted timesheets can be approved.
+BadStatusForRefuse = Only submitted timesheets can be refused.
+AlreadyDraft = This timesheet is already in draft status.


### PR DESCRIPTION
## Summary
- centralize status transitions inside `TimesheetWeek` to validate workflow changes and record timestamps
- switch the card actions to call the class helpers, translating functional errors and respecting validator permissions
- add language strings for the new workflow error messages

## Testing
- php -l class/timesheetweek.class.php
- php -l timesheetweek_card.php

------
https://chatgpt.com/codex/tasks/task_e_68e388b17210832eb6d0e56718e312cc