### PR TITLE
Hide tasks not relevant to weekly timesheet card

### DIFF
--- a/class/timesheetweek.class.php
+++ b/class/timesheetweek.class.php
@@ -854,8 +854,9 @@ class TimesheetWeek extends CommonObject
 
 		// Several ways tasks can be assigned -> llx_element_contact with element='project_task'
 		// Note: Some installs store user id into fk_socpeople (legacy)
-		$sql = "SELECT t.rowid as task_id, t.label as task_label,";
-		$sql .= " p.rowid as project_id, p.ref as project_ref, p.title as project_title";
+                $sql = "SELECT t.rowid as task_id, t.label as task_label, t.ref as task_ref,";
+                $sql .= " t.progress as task_progress, t.fk_statut as task_status, t.dateo as task_date_start, t.datee as task_date_end,";
+                $sql .= " p.rowid as project_id, p.ref as project_ref, p.title as project_title";
 		$sql .= " FROM ".MAIN_DB_PREFIX."projet_task t";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."projet p ON p.rowid = t.fk_projet";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."element_contact ec ON ec.element_id = t.rowid";
@@ -864,7 +865,7 @@ class TimesheetWeek extends CommonObject
 		$sql .= " WHERE p.entity IN (".getEntity('project').")";
 		$sql .= " AND ctc.element = 'project_task'";
 		$sql .= " AND (ec.fk_socpeople = ".$userid." OR u.rowid = ".$userid.")";
-		$sql .= " GROUP BY t.rowid, t.label, p.rowid, p.ref, p.title";
+                $sql .= " GROUP BY t.rowid, t.label, t.ref, t.progress, t.fk_statut, t.dateo, t.datee, p.rowid, p.ref, p.title";
 		$sql .= " ORDER BY p.ref, t.label";
 
 		$res = $this->db->query($sql);
@@ -874,13 +875,18 @@ class TimesheetWeek extends CommonObject
 		}
 		$out = array();
 		while ($obj = $this->db->fetch_object($res)) {
-			$out[] = array(
-				'task_id' => (int) $obj->task_id,
-				'task_label' => (string) $obj->task_label,
-				'project_id' => (int) $obj->project_id,
-				'project_ref' => (string) $obj->project_ref,
-				'project_title' => (string) $obj->project_title,
-			);
+                        $out[] = array(
+                                'task_id' => (int) $obj->task_id,
+                                'task_label' => (string) $obj->task_label,
+                                'task_ref' => (string) $obj->task_ref,
+                                'task_progress' => ($obj->task_progress !== null ? (float) $obj->task_progress : null),
+                                'task_status' => ($obj->task_status !== null ? (int) $obj->task_status : null),
+                                'task_date_start' => ($obj->task_date_start !== null ? (string) $obj->task_date_start : null),
+                                'task_date_end' => ($obj->task_date_end !== null ? (string) $obj->task_date_end : null),
+                                'project_id' => (int) $obj->project_id,
+                                'project_ref' => (string) $obj->project_ref,
+                                'project_title' => (string) $obj->project_title,
+                        );
 		}
 		$this->db->free($res);
 		return $out;

--- a/class/timesheetweek.class.php
+++ b/class/timesheetweek.class.php
@@ -854,8 +854,10 @@ class TimesheetWeek extends CommonObject
 
 		// Several ways tasks can be assigned -> llx_element_contact with element='project_task'
 		// Note: Some installs store user id into fk_socpeople (legacy)
-                $sql = "SELECT t.rowid as task_id, t.label as task_label, t.ref as task_ref,";
-                $sql .= " t.progress as task_progress, t.fk_statut as task_status, t.dateo as task_date_start, t.datee as task_date_end,";
+               // EN: Fetch extra task metadata so the card can filter items (status, progress, dates).
+               // FR: Récupère des métadonnées supplémentaires pour que la carte puisse filtrer (statut, avancement, dates).
+               $sql = "SELECT t.rowid as task_id, t.label as task_label, t.ref as task_ref,";
+               $sql .= " t.progress as task_progress, t.fk_statut as task_status, t.dateo as task_date_start, t.datee as task_date_end,";
                 $sql .= " p.rowid as project_id, p.ref as project_ref, p.title as project_title";
 		$sql .= " FROM ".MAIN_DB_PREFIX."projet_task t";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."projet p ON p.rowid = t.fk_projet";
@@ -865,7 +867,9 @@ class TimesheetWeek extends CommonObject
 		$sql .= " WHERE p.entity IN (".getEntity('project').")";
 		$sql .= " AND ctc.element = 'project_task'";
 		$sql .= " AND (ec.fk_socpeople = ".$userid." OR u.rowid = ".$userid.")";
-                $sql .= " GROUP BY t.rowid, t.label, t.ref, t.progress, t.fk_statut, t.dateo, t.datee, p.rowid, p.ref, p.title";
+               // EN: Group by the extra fields to keep SQL strict mode satisfied once new columns are selected.
+               // FR: Ajoute les nouveaux champs dans le GROUP BY pour respecter le mode strict SQL après sélection.
+               $sql .= " GROUP BY t.rowid, t.label, t.ref, t.progress, t.fk_statut, t.dateo, t.datee, p.rowid, p.ref, p.title";
 		$sql .= " ORDER BY p.ref, t.label";
 
 		$res = $this->db->query($sql);
@@ -875,7 +879,9 @@ class TimesheetWeek extends CommonObject
 		}
 		$out = array();
 		while ($obj = $this->db->fetch_object($res)) {
-                        $out[] = array(
+                       // EN: Return the enriched task information so the caller can apply advanced filters.
+                       // FR: Retourne les informations enrichies de la tâche pour permettre des filtres avancés côté appelant.
+                       $out[] = array(
                                 'task_id' => (int) $obj->task_id,
                                 'task_label' => (string) $obj->task_label,
                                 'task_ref' => (string) $obj->task_ref,

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -961,6 +961,8 @@ JS;
 			if (!isset($tasksById[$tid])) $missing[] = (int)$tid;
 		}
 		if (!empty($missing)) {
+                        // EN: Bring in the same enriched task metadata for unassigned lines to keep filtering consistent.
+                        // FR: Récupère les mêmes métadonnées enrichies pour les lignes non assignées afin d'harmoniser le filtrage.
                         $sqlMiss = "SELECT t.rowid as task_id, t.label as task_label, t.ref as task_ref, t.progress as task_progress,
                                                         t.fk_statut as task_status, t.dateo as task_date_start, t.datee as task_date_end,
                                                         p.rowid as project_id, p.ref as project_ref, p.title as project_title
@@ -991,6 +993,8 @@ JS;
         $weekdates = array();
         $weekStartDate = null;
         $weekEndDate = null;
+        // EN: Derive week boundaries defensively because the week metadata can be missing on drafts.
+        // FR: Calcule prudemment les bornes de semaine car les métadonnées peuvent manquer sur les brouillons.
         if (!empty($object->year) && !empty($object->week)) {
                 $dto = new DateTime();
                 $dto->setISODate((int)$object->year, (int)$object->week);
@@ -1007,6 +1011,8 @@ JS;
         }
 
         if (!empty($tasks)) {
+                // EN: Define closed statuses dynamically to remain compatible across Dolibarr versions.
+                // FR: Définit dynamiquement les statuts clos pour rester compatible entre versions de Dolibarr.
                 $closedStatuses = array();
                 if (defined('Task::STATUS_DONE')) $closedStatuses[] = Task::STATUS_DONE;
                 if (defined('Task::STATUS_CLOSED')) $closedStatuses[] = Task::STATUS_CLOSED;
@@ -1019,6 +1025,8 @@ JS;
 
                 $filteredTasks = array();
                 foreach ($tasks as $t) {
+                        // EN: Skip tasks already completed or closed to declutter the weekly view.
+                        // FR: Ignore les tâches déjà terminées ou clôturées pour épurer la vue hebdomadaire.
                         $progress = isset($t['task_progress']) ? $t['task_progress'] : null;
                         if ($progress !== null && (float)$progress >= 100) {
                                 continue;
@@ -1034,6 +1042,8 @@ JS;
                                 }
                         }
 
+                        // EN: Extract scheduling information to hide tasks outside the sheet week.
+                        // FR: Analyse les dates de planification pour masquer les tâches hors de la semaine de la feuille.
                         $startRaw = isset($t['task_date_start']) ? $t['task_date_start'] : null;
                         $endRaw = isset($t['task_date_end']) ? $t['task_date_end'] : null;
                         $startTs = null;
@@ -1055,6 +1065,8 @@ JS;
                                 }
                         }
 
+                        // EN: Ignore tasks that start after the sheet week or end before it.
+                        // FR: Ignore les tâches qui commencent après la semaine ou se terminent avant celle-ci.
                         if ($weekStartTs !== null && $weekEndTs !== null && $startTs !== null && $startTs > $weekEndTs) {
                                 continue;
                         }
@@ -1085,6 +1097,8 @@ JS;
 		echo '<tr class="liste_titre">';
                 echo '<th>'.$langs->trans("ProjectTaskColumn").'</th>';
                 foreach ($days as $d) {
+                        // EN: Render day headers safely even if week dates are undefined.
+                        // FR: Affiche les en-têtes de jours en sécurité même sans dates de semaine définies.
                         $labelDate = '';
                         if (!empty($weekdates[$d])) {
                                 $tmpTs = strtotime($weekdates[$d]);


### PR DESCRIPTION
## Summary
- expose task progress, status, and dates when fetching assigned tasks
- filter the weekly card to omit completed, closed, or out-of-week tasks
- guard table headers against missing week dates when rendering the grid

## Testing
- php -l timesheetweek_card.php
- php -l class/timesheetweek.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e58d0d6e94832e9a834bb495394171