### PR TITLE
feat: création rapide depuis le menu supérieur

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 - Affichage du libellé "Zone" devant chaque sélecteur quotidien.
 - Ajout de la traduction "Meals" en "Repas".
 - Ajout du script de mise à jour SQL (`sql/update_all.sql`) pour créer les compteurs hebdomadaires sur les données existantes.
+- Ajout d'un accès rapide à la création de feuille d'heures via le menu supérieur.
 
 ## 1.0
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Description of the module...
 - Suivi des compteurs hebdomadaires de zones et de paniers pour chaque feuille de temps.
 - Recalcul automatique des compteurs de zones et de paniers lors de chaque enregistrement.
 - Affichage des compteurs de zones et de paniers dans la liste des feuilles hebdomadaires.
+- Création rapide d'une feuille d'heures depuis le raccourci "Ajouter" du menu supérieur.
 
 <!--
 ![Screenshot timesheetweek](img/screenshot_timesheetweek.png?raw=true "TimesheetWeek"){imgmd}

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -51,27 +51,24 @@ class ActionsTimesheetweek
      */
     public function menuDropdownQuickaddItems($parameters, &$object, &$action, $hookmanager)
     {
-        global $conf, $langs, $user;
+        global $langs, $user;
 
         // EN: Reset hook containers before populating the dropdown.
         // FR: Réinitialiser les conteneurs du hook avant de remplir le menu déroulant.
         $this->results = array();
         $this->resprints = '';
 
-        // EN: Skip the quick entry when the module is disabled.
-        // FR: Ignorer l'entrée rapide lorsque le module est désactivé.
-        if (empty($conf->timesheetweek->enabled) || !isModEnabled('timesheetweek')) {
-            return 0;
-        }
-
         // EN: Load module translations to expose localized labels.
         // FR: Charger les traductions du module pour exposer les libellés localisés.
         $langs->loadLangs(array('timesheetweek@timesheetweek'));
 
-        // EN: Stop if the user has no permission to write any weekly timesheet.
-        // FR: Arrêter si l'utilisateur n'a aucun droit d'écriture sur les feuilles hebdomadaires.
-        if (empty($user->rights->timesheetweek->write) && empty($user->rights->timesheetweek->writeChild) && empty($user->rights->timesheetweek->writeAll)) {
-            return 0;
+        // EN: Evaluate user permissions to control quick creation visibility.
+        // FR: Évaluer les droits de l'utilisateur pour contrôler la visibilité de la création rapide.
+        $hasWriteRight = !empty($user->rights->timesheetweek->write) || !empty($user->rights->timesheetweek->writeChild) || !empty($user->rights->timesheetweek->writeAll);
+        if (!$hasWriteRight && method_exists($user, 'hasRight')) {
+            // EN: Consolidate Dolibarr helper checks when available.
+            // FR: Consolider les vérifications via les helpers Dolibarr lorsqu'ils sont disponibles.
+            $hasWriteRight = $user->hasRight('timesheetweek', 'write') || $user->hasRight('timesheetweek', 'writeChild') || $user->hasRight('timesheetweek', 'writeAll');
         }
 
         // EN: Inject the quick creation entry with translated metadata.
@@ -83,7 +80,9 @@ class ActionsTimesheetweek
             'title' => 'QuickCreateTimesheetWeek@timesheetweek',
             'name' => 'TimesheetWeek@timesheetweek',
             'picto' => 'bookcal',
-            'activation' => isModEnabled('timesheetweek'),
+            // EN: Activate the quick add entry only when modules and rights allow it.
+            // FR: Activer l'entrée de création rapide uniquement lorsque les modules et droits le permettent.
+            'activation' => isModEnabled('product') && $hasWriteRight,
             'position' => 100,
         );
 

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Hook class for TimesheetWeek module.
+ * Classe de hook pour le module TimesheetWeek.
+ */
+class ActionsTimesheetweek
+{
+    /** @var DoliDB */
+    public $db;
+
+    /** @var string */
+    public $error = '';
+
+    /** @var array */
+    public $errors = array();
+
+    /** @var string */
+    public $resprints = '';
+
+    /**
+     * Constructor.
+     * Constructeur.
+     *
+     * @param DoliDB $db Database handler.
+     */
+    public function __construct($db)
+    {
+        // EN: Store the database handler for potential future hooks.
+        // FR: Conserver le gestionnaire de base de données pour de futurs hooks.
+        $this->db = $db;
+    }
+
+    /**
+     * Add TimesheetWeek entry into the quick add dropdown of the top menu.
+     * Ajouter une entrée TimesheetWeek dans le menu rapide du bandeau supérieur.
+     *
+     * @param array          $parameters Hook parameters / Paramètres du hook
+     * @param CommonObject   $object     Current object / Objet courant
+     * @param string         $action     Current action / Action courante
+     * @param HookManager    $hookmanager Hook manager instance / Gestionnaire de hooks
+     *
+     * @return int Status / Statut
+     */
+    public function printTopMenuQuickAddDropdown($parameters, &$object, &$action, $hookmanager)
+    {
+        global $langs, $user;
+
+        // EN: Load module translations to display the quick add label.
+        // FR: Charger les traductions du module pour afficher le libellé de création rapide.
+        $langs->loadLangs(array('timesheetweek@timesheetweek'));
+
+        // EN: Stop if the user has no write permission on weekly timesheets.
+        // FR: Stopper si l'utilisateur n'a aucun droit d'écriture sur les feuilles hebdomadaires.
+        if (empty($user->rights->timesheetweek->write) && empty($user->rights->timesheetweek->writeChild) && empty($user->rights->timesheetweek->writeAll)) {
+            return 0;
+        }
+
+        // EN: Build the URL leading to the creation form.
+        // FR: Construire l'URL menant au formulaire de création.
+        $url = dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create';
+
+        // EN: Prepare the translated label for the quick action.
+        // FR: Préparer le libellé traduit pour l'action rapide.
+        $label = $langs->trans('QuickCreateTimesheetWeek');
+
+        // EN: Reuse the module pictogram to keep the look consistent.
+        // FR: Réutiliser le pictogramme du module pour conserver la cohérence visuelle.
+        $icon = img_picto('', 'bookcal@timesheetweek', 'class="pictofixedwidth"');
+
+        // EN: Print the quick add entry with escaped content.
+        // FR: Afficher l'entrée de création rapide avec un contenu échappé.
+        $this->resprints .= '<a class="dropdown-item" href="' . dol_escape_htmltag($url) . '">' . $icon . dol_escape_htmltag($label) . '</a>';
+
+        // EN: Allow other modules to continue injecting their entries.
+        // FR: Laisser les autres modules poursuivre l'injection de leurs entrées.
+        return 0;
+    }
+}

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -80,9 +80,9 @@ class ActionsTimesheetweek
             'title' => 'QuickCreateTimesheetWeek@timesheetweek',
             'name' => 'TimesheetWeek@timesheetweek',
             'picto' => 'bookcal',
-            // EN: Activate the quick add entry only when modules and rights allow it.
-            // FR: Activer l'entrée de création rapide uniquement lorsque les modules et droits le permettent.
-            'activation' => isModEnabled('product') && $hasWriteRight,
+            // EN: Activate the quick add entry only when the module is enabled and rights allow it.
+            // FR: Activer l'entrée de création rapide uniquement lorsque le module est actif et que les droits le permettent.
+            'activation' => isModEnabled('timesheetweek') && $hasWriteRight,
             'position' => 100,
         );
 

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -51,38 +51,40 @@ class ActionsTimesheetweek
      */
     public function menuDropdownQuickaddItems($parameters, &$object, &$action, $hookmanager)
     {
-        global $langs, $user;
+        global $conf, $langs, $user;
 
         // EN: Reset hook containers before populating the dropdown.
         // FR: Réinitialiser les conteneurs du hook avant de remplir le menu déroulant.
         $this->results = array();
         $this->resprints = '';
 
+        // EN: Stop early when the module is disabled to avoid useless processing.
+        // FR: Stopper immédiatement lorsque le module est désactivé pour éviter un traitement inutile.
+        if (empty($conf->timesheetweek->enabled)) {
+            return 0;
+        }
+
+        // EN: Check write permissions to decide if the quick add entry must be shown.
+        // FR: Vérifier les permissions d'écriture pour décider si l'entrée de création rapide doit être affichée.
+        $hasWriteRight = !empty($user->rights->timesheetweek->write)
+            || !empty($user->rights->timesheetweek->writeChild)
+            || !empty($user->rights->timesheetweek->writeAll);
+        if (!$hasWriteRight) {
+            return 0;
+        }
+
         // EN: Load module translations to expose localized labels.
         // FR: Charger les traductions du module pour exposer les libellés localisés.
         $langs->loadLangs(array('timesheetweek@timesheetweek'));
 
-        // EN: Evaluate user permissions to control quick creation visibility.
-        // FR: Évaluer les droits de l'utilisateur pour contrôler la visibilité de la création rapide.
-        $hasWriteRight = !empty($user->rights->timesheetweek->write) || !empty($user->rights->timesheetweek->writeChild) || !empty($user->rights->timesheetweek->writeAll);
-        if (!$hasWriteRight && method_exists($user, 'hasRight')) {
-            // EN: Consolidate Dolibarr helper checks when available.
-            // FR: Consolider les vérifications via les helpers Dolibarr lorsqu'ils sont disponibles.
-            $hasWriteRight = $user->hasRight('timesheetweek', 'write') || $user->hasRight('timesheetweek', 'writeChild') || $user->hasRight('timesheetweek', 'writeAll');
-        }
-
-        // EN: Inject the quick creation entry with translated metadata.
-        // FR: Injecter l'entrée de création rapide avec des métadonnées traduites.
-        $this->results[0] = array(
-            // EN: Link directly to the custom module path exposed by Dolibarr.
-            // FR: Lien direct vers le chemin custom du module exposé par Dolibarr.
-            'url' => '/custom/timesheetweek/timesheetweek_card.php?action=create',
+        // EN: Provide the quick add entry with a Dolibarr-safe URL and translated metadata.
+        // FR: Fournir l'entrée de création rapide avec une URL Dolibarr sécurisée et des métadonnées traduites.
+        $this->results[] = array(
+            'url' => dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create',
             'title' => 'QuickCreateTimesheetWeek@timesheetweek',
             'name' => 'TimesheetWeek@timesheetweek',
             'picto' => 'bookcal',
-            // EN: Activate the quick add entry only when the module is enabled and rights allow it.
-            // FR: Activer l'entrée de création rapide uniquement lorsque le module est actif et que les droits le permettent.
-            'activation' => isModEnabled('timesheetweek') && $hasWriteRight,
+            'activation' => 1,
             'position' => 100,
         );
 

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -77,7 +77,9 @@ class ActionsTimesheetweek
         // EN: Inject the quick creation entry with translated metadata.
         // FR: Injecter l'entrée de création rapide avec des métadonnées traduites.
         $this->results[0] = array(
-            'url' => dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create',
+            // EN: Link directly to the custom module path exposed by Dolibarr.
+            // FR: Lien direct vers le chemin custom du module exposé par Dolibarr.
+            'url' => '/custom/timesheetweek/timesheetweek_card.php?action=create',
             'title' => 'QuickCreateTimesheetWeek@timesheetweek',
             'name' => 'TimesheetWeek@timesheetweek',
             'picto' => 'bookcal',

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -31,8 +31,8 @@ class ActionsTimesheetweek
     }
 
     /**
-     * Add TimesheetWeek entry into the quick add dropdown of the top menu.
-     * Ajouter une entrée TimesheetWeek dans le menu rapide du bandeau supérieur.
+     * Add TimesheetWeek entry into the quick add dropdown of the top right menu.
+     * Ajouter une entrée TimesheetWeek dans le menu rapide du bandeau supérieur droit.
      *
      * @param array          $parameters Hook parameters / Paramètres du hook
      * @param CommonObject   $object     Current object / Objet courant
@@ -41,9 +41,15 @@ class ActionsTimesheetweek
      *
      * @return int Status / Statut
      */
-    public function printTopMenuQuickAddDropdown($parameters, &$object, &$action, $hookmanager)
+    public function printTopRightMenu($parameters, &$object, &$action, $hookmanager)
     {
         global $langs, $user;
+
+        // EN: Only add the entry when the quick add dropdown is being rendered.
+        // FR: Ajouter l'entrée uniquement lorsque le menu déroulant de création rapide est rendu.
+        if (empty($parameters['currentcontext']) || $parameters['currentcontext'] !== 'quickadddropdown') {
+            return 0;
+        }
 
         // EN: Load module translations to display the quick add label.
         // FR: Charger les traductions du module pour afficher le libellé de création rapide.

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -58,33 +58,27 @@ class ActionsTimesheetweek
         $this->results = array();
         $this->resprints = '';
 
-        // EN: Stop early when the module is disabled to avoid useless processing.
-        // FR: Stopper immédiatement lorsque le module est désactivé pour éviter un traitement inutile.
-        if (empty($conf->timesheetweek->enabled)) {
-            return 0;
-        }
-
-        // EN: Check write permissions to decide if the quick add entry must be shown.
-        // FR: Vérifier les permissions d'écriture pour décider si l'entrée de création rapide doit être affichée.
-        $hasWriteRight = !empty($user->rights->timesheetweek->write)
-            || !empty($user->rights->timesheetweek->writeChild)
-            || !empty($user->rights->timesheetweek->writeAll);
-        if (!$hasWriteRight) {
-            return 0;
-        }
-
         // EN: Load module translations to expose localized labels.
         // FR: Charger les traductions du module pour exposer les libellés localisés.
         $langs->loadLangs(array('timesheetweek@timesheetweek'));
 
-        // EN: Provide the quick add entry with a Dolibarr-safe URL and translated metadata.
-        // FR: Fournir l'entrée de création rapide avec une URL Dolibarr sécurisée et des métadonnées traduites.
-        $this->results[] = array(
-            'url' => dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create',
+        // EN: Evaluate user permissions to control quick creation visibility.
+        // FR: Évaluer les droits de l'utilisateur pour contrôler la visibilité de la création rapide.
+
+        $hasWriteRight = $user->hasRight('timesheetweek', 'timesheetweek', 'write') || $user->hasRight('timesheetweek', 'timesheetweek', 'writeChild') || $user->hasRight('timesheetweek', 'timesheetweek', 'writeAll');
+
+        // EN: Inject the quick creation entry with translated metadata.
+        // FR: Injecter l'entrée de création rapide avec des métadonnées traduites.
+        $this->results[0] = array(
+            // EN: Link directly to the custom module path exposed by Dolibarr.
+            // FR: Lien direct vers le chemin custom du module exposé par Dolibarr.
+            'url' => '/custom/timesheetweek/timesheetweek_card.php?action=create',
             'title' => 'QuickCreateTimesheetWeek@timesheetweek',
-            'name' => 'TimesheetWeek@timesheetweek',
+            'name' => 'Timesheet@timesheetweek',
             'picto' => 'bookcal',
-            'activation' => 1,
+            // EN: Activate the quick add entry only when the module is enabled and rights allow it.
+            // FR: Activer l'entrée de création rapide uniquement lorsque le module est actif et que les droits le permettent.
+            'activation' => isModEnabled('timesheetweek') && ($hasWriteRight),
             'position' => 100,
         );
 

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -18,6 +18,14 @@ class ActionsTimesheetweek
     public $resprints = '';
 
     /**
+     * Hook results container.
+     * Tableau des résultats du hook.
+     *
+     * @var array
+     */
+    public $results = array();
+
+    /**
      * Constructor.
      * Constructeur.
      *
@@ -31,8 +39,8 @@ class ActionsTimesheetweek
     }
 
     /**
-     * Add TimesheetWeek entry into the quick add dropdown of the top right menu.
-     * Ajouter une entrée TimesheetWeek dans le menu rapide du bandeau supérieur droit.
+     * Inject TimesheetWeek entry into the quick add dropdown menu.
+     * Injecter une entrée TimesheetWeek dans le menu déroulant de création rapide.
      *
      * @param array          $parameters Hook parameters / Paramètres du hook
      * @param CommonObject   $object     Current object / Objet courant
@@ -41,44 +49,42 @@ class ActionsTimesheetweek
      *
      * @return int Status / Statut
      */
-    public function printTopRightMenu($parameters, &$object, &$action, $hookmanager)
+    public function menuDropdownQuickaddItems($parameters, &$object, &$action, $hookmanager)
     {
-        global $langs, $user;
+        global $conf, $langs, $user;
 
-        // EN: Only add the entry when the quick add dropdown is being rendered.
-        // FR: Ajouter l'entrée uniquement lorsque le menu déroulant de création rapide est rendu.
-        if (empty($parameters['currentcontext']) || $parameters['currentcontext'] !== 'quickadddropdown') {
+        // EN: Reset hook containers before populating the dropdown.
+        // FR: Réinitialiser les conteneurs du hook avant de remplir le menu déroulant.
+        $this->results = array();
+        $this->resprints = '';
+
+        // EN: Skip the quick entry when the module is disabled.
+        // FR: Ignorer l'entrée rapide lorsque le module est désactivé.
+        if (empty($conf->timesheetweek->enabled) || !isModEnabled('timesheetweek')) {
             return 0;
         }
 
-        // EN: Load module translations to display the quick add label.
-        // FR: Charger les traductions du module pour afficher le libellé de création rapide.
+        // EN: Load module translations to expose localized labels.
+        // FR: Charger les traductions du module pour exposer les libellés localisés.
         $langs->loadLangs(array('timesheetweek@timesheetweek'));
 
-        // EN: Stop if the user has no write permission on weekly timesheets.
-        // FR: Stopper si l'utilisateur n'a aucun droit d'écriture sur les feuilles hebdomadaires.
+        // EN: Stop if the user has no permission to write any weekly timesheet.
+        // FR: Arrêter si l'utilisateur n'a aucun droit d'écriture sur les feuilles hebdomadaires.
         if (empty($user->rights->timesheetweek->write) && empty($user->rights->timesheetweek->writeChild) && empty($user->rights->timesheetweek->writeAll)) {
             return 0;
         }
 
-        // EN: Build the URL leading to the creation form.
-        // FR: Construire l'URL menant au formulaire de création.
-        $url = dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create';
+        // EN: Inject the quick creation entry with translated metadata.
+        // FR: Injecter l'entrée de création rapide avec des métadonnées traduites.
+        $this->results[0] = array(
+            'url' => dol_buildpath('/timesheetweek/timesheetweek_card.php', 1) . '?action=create',
+            'title' => 'QuickCreateTimesheetWeek@timesheetweek',
+            'name' => 'TimesheetWeek@timesheetweek',
+            'picto' => 'bookcal',
+            'activation' => isModEnabled('timesheetweek'),
+            'position' => 100,
+        );
 
-        // EN: Prepare the translated label for the quick action.
-        // FR: Préparer le libellé traduit pour l'action rapide.
-        $label = $langs->trans('QuickCreateTimesheetWeek');
-
-        // EN: Reuse the module pictogram to keep the look consistent.
-        // FR: Réutiliser le pictogramme du module pour conserver la cohérence visuelle.
-        $icon = img_picto('', 'bookcal@timesheetweek', 'class="pictofixedwidth"');
-
-        // EN: Print the quick add entry with escaped content.
-        // FR: Afficher l'entrée de création rapide avec un contenu échappé.
-        $this->resprints .= '<a class="dropdown-item" href="' . dol_escape_htmltag($url) . '">' . $icon . dol_escape_htmltag($label) . '</a>';
-
-        // EN: Allow other modules to continue injecting their entries.
-        // FR: Laisser les autres modules poursuivre l'injection de leurs entrées.
         return 0;
     }
 }

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -123,11 +123,11 @@ class modTimesheetWeek extends DolibarrModules
 			),
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 			/* BEGIN MODULEBUILDER HOOKSCONTEXTS */
-                        // EN: Register the quick creation hook for the top menu dropdown.
-                        // FR: Enregistrer le hook de création rapide pour le menu supérieur.
+                        // EN: Register the top right menu hook to inject quick creation entry.
+                        // FR: Enregistrer le hook du menu supérieur droit pour injecter l'entrée de création rapide.
                         'hooks' => array(
                                 'data' => array(
-                                        'topmenu-quickadd-dropdown',
+                                        'toprightmenu',
                                 ),
                                 'entity' => '0',
                         ),

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -123,13 +123,14 @@ class modTimesheetWeek extends DolibarrModules
 			),
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 			/* BEGIN MODULEBUILDER HOOKSCONTEXTS */
-			'hooks' => array(
-				//   'data' => array(
-				//       'hookcontext1',
-				//       'hookcontext2',
-				//   ),
-				//   'entity' => '0',
-			),
+                        // EN: Register the quick creation hook for the top menu dropdown.
+                        // FR: Enregistrer le hook de création rapide pour le menu supérieur.
+                        'hooks' => array(
+                                'data' => array(
+                                        'topmenu-quickadd-dropdown',
+                                ),
+                                'entity' => '0',
+                        ),
 			/* END MODULEBUILDER HOOKSCONTEXTS */
 			// Set this to 1 if features of module are opened to external users
 			'moduleforexternal' => 0,

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -37,6 +37,7 @@ TimesheetWeek = Timesheet week
 TimesheetWeekList = Timesheet weeks
 ListTimesheetWeek = Timesheet weeks
 NewTimesheetWeek = New timesheet week
+QuickCreateTimesheetWeek = Quick-create a weekly timesheet
 List TimesheetWeek = Timesheet weeks
 New TimesheetWeek = New timesheet week
 ShowTimesheetWeek = Show timesheet week %s

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -37,6 +37,7 @@ TimesheetWeek = Feuille de temps hebdomadaire
 # TimesheetWeekList = Feuilles de temps hebdomadaires
 ListTimesheetWeek = Feuilles de temps hebdomadaires
 NewTimesheetWeek = Nouvelle feuille de temps hebdomadaire
+QuickCreateTimesheetWeek = Création rapide d'une feuille de temps hebdomadaire
 TimesheetWeekList = Liste des feuilles de temps
 TimesheetWeekNew = Nouvelle feuille de temps
 ShowTimesheetWeek = Afficher la feuille de temps %s


### PR DESCRIPTION
## Summary
- enregistrer le hook du menu supérieur pour le module TimesheetWeek
- proposer l'entrée de création rapide de feuille hebdomadaire avec permissions et traductions
- documenter l'accès rapide dans la documentation utilisateur

## Testing
- php -l class/actions_timesheetweek.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e5eb4ec66c832ea307aa73a3635eca