### PR TITLE
feat: compatibilité Multicompany pour TimesheetWeek

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Redirection automatique vers la feuille existante en cas de création en doublon / Automatic redirect to the existing sheet when attempting a duplicate creation.
 - Ajout d'un accès rapide à la création de feuille d'heures via le menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and numbering sequences.
+- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 - Ajout du script de mise à jour SQL (`sql/update_all.sql`) pour créer les compteurs hebdomadaires sur les données existantes.
 - Redirection automatique vers la feuille existante en cas de création en doublon / Automatic redirect to the existing sheet when attempting a duplicate creation.
 - Ajout d'un accès rapide à la création de feuille d'heures via le menu supérieur.
+- Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and numbering sequences.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and numbering sequences.
 - Inscription et retrait automatiques de la configuration Multicompany lors de l'activation/désactivation du module / Automatic registration and cleanup of the Multicompany configuration on module enable/disable.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
+- Harmonisation du filtre de semaine avec celui de la fiche via le sélecteur ISO / Harmonized week filter with the card using the ISO selector.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Redirection automatique vers la feuille existante en cas de création en doublon / Automatic redirect to the existing sheet when attempting a duplicate creation.
 - Ajout d'un accès rapide à la création de feuille d'heures via le menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and numbering sequences.
+- Inscription et retrait automatiques de la configuration Multicompany lors de l'activation/désactivation du module / Automatic registration and cleanup of the Multicompany configuration on module enable/disable.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
 
 ## 1.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
 - Passage du filtre de semaine en multi-sélection pour regrouper plusieurs périodes dans la liste / Week filter upgraded to multi-select to group several periods in the list.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured timesheet and line SQL queries with entity scoping for Multicompany.
 - Filtre Multicompany de l'environnement aligné sur le multiselect natif dans la liste / Multicompany environment filter aligned with the native multiselect in the list.
+- Réorganisation des options de partage Multicompany pour séparer les feuilles et la numérotation avec les pictogrammes adaptés / Reorganised Multicompany sharing options to separate sheets and numbering with suitable pictograms.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
 - Harmonisation du filtre de semaine avec celui de la fiche via le sélecteur ISO / Harmonized week filter with the card using the ISO selector.
 - Passage du filtre de semaine en multi-sélection pour regrouper plusieurs périodes dans la liste / Week filter upgraded to multi-select to group several periods in the list.
+- Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured timesheet and line SQL queries with entity scoping for Multicompany.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 - Inscription et retrait automatiques de la configuration Multicompany lors de l'activation/désactivation du module / Automatic registration and cleanup of the Multicompany configuration on module enable/disable.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
 - Harmonisation du filtre de semaine avec celui de la fiche via le sélecteur ISO / Harmonized week filter with the card using the ISO selector.
+- Passage du filtre de semaine en multi-sélection pour regrouper plusieurs périodes dans la liste / Week filter upgraded to multi-select to group several periods in the list.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@
 - Harmonisation du filtre de semaine avec celui de la fiche via le sélecteur ISO / Harmonized week filter with the card using the ISO selector.
 - Passage du filtre de semaine en multi-sélection pour regrouper plusieurs périodes dans la liste / Week filter upgraded to multi-select to group several periods in the list.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured timesheet and line SQL queries with entity scoping for Multicompany.
+- Filtre Multicompany de l'environnement aligné sur le multiselect natif dans la liste / Multicompany environment filter aligned with the native multiselect in the list.
 
 ## 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,12 +12,13 @@
 - Ajout d'un accès rapide à la création de feuille d'heures via le menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and numbering sequences.
 - Inscription et retrait automatiques de la configuration Multicompany lors de l'activation/désactivation du module / Automatic registration and cleanup of the Multicompany configuration on module enable/disable.
-- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity details on list and card when Multicompany is active.
+- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany, avec badge natif sous la référence en cas d'entité différente / Display entity details on list and card when Multicompany is active, with a native badge under the reference when the entity differs.
 - Harmonisation du filtre de semaine avec celui de la fiche via le sélecteur ISO / Harmonized week filter with the card using the ISO selector.
 - Passage du filtre de semaine en multi-sélection pour regrouper plusieurs périodes dans la liste / Week filter upgraded to multi-select to group several periods in the list.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured timesheet and line SQL queries with entity scoping for Multicompany.
 - Filtre Multicompany de l'environnement aligné sur le multiselect natif dans la liste / Multicompany environment filter aligned with the native multiselect in the list.
 - Réorganisation des options de partage Multicompany pour séparer les feuilles et la numérotation avec les pictogrammes adaptés / Reorganised Multicompany sharing options to separate sheets and numbering with suitable pictograms.
+- Inversion des couleurs des statuts "Scellée" et "Refusée" pour reprendre les repères Dolibarr / Swapped colors of "Sealed" and "Refused" statuses to match Dolibarr visual cues.
 
 ## 1.0
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Description of the module...
 - Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
 - Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
+- Filtre de semaine en multi-sélection pour combiner plusieurs périodes directement depuis la liste / Multi-select week filter to combine several periods directly from the list.
 
 <!--
 ![Screenshot timesheetweek](img/screenshot_timesheetweek.png?raw=true "TimesheetWeek"){imgmd}

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Description of the module...
 - Création rapide d'une feuille d'heures depuis le raccourci "Ajouter" du menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
 - Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
-- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
+- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany, avec badge natif sous la référence lorsque l'entité diffère / Display entity information in list and card when using Multicompany, with a native badge under the reference when the entity differs.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured SQL queries on sheets and lines with entity scoping for Multicompany.
 - Filtre multisélection de l'environnement respectant l'interface native de Dolibarr en Multicompany / Multiselect environment filter following Dolibarr native Multicompany interface.
 - Réorganisation des options Multicompany pour distinguer partage et numérotation avec les pictogrammes natifs / Reorganised Multicompany sharing options to split sharing and numbering with native pictograms.
+- Inversion des couleurs des statuts "Scellée" et "Refusée" pour correspondre au code couleur Dolibarr / Swapped colors of "Sealed" and "Refused" statuses to follow Dolibarr color codes.
 - Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
 - Filtre de semaine en multi-sélection pour combiner plusieurs périodes directement depuis la liste / Multi-select week filter to combine several periods directly from the list.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Description of the module...
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
 - Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
+- Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured SQL queries on sheets and lines with entity scoping for Multicompany.
 - Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
 - Filtre de semaine en multi-sélection pour combiner plusieurs périodes directement depuis la liste / Multi-select week filter to combine several periods directly from the list.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Description of the module...
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
 - Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
+- Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
 
 <!--
 ![Screenshot timesheetweek](img/screenshot_timesheetweek.png?raw=true "TimesheetWeek"){imgmd}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Description of the module...
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured SQL queries on sheets and lines with entity scoping for Multicompany.
 - Filtre multisélection de l'environnement respectant l'interface native de Dolibarr en Multicompany / Multiselect environment filter following Dolibarr native Multicompany interface.
+- Réorganisation des options Multicompany pour distinguer partage et numérotation avec les pictogrammes natifs / Reorganised Multicompany sharing options to split sharing and numbering with native pictograms.
 - Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
 - Filtre de semaine en multi-sélection pour combiner plusieurs périodes directement depuis la liste / Multi-select week filter to combine several periods directly from the list.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Description of the module...
 - Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
 - Sécurisation des requêtes SQL sur les feuilles et lignes par entité pour Multicompany / Secured SQL queries on sheets and lines with entity scoping for Multicompany.
+- Filtre multisélection de l'environnement respectant l'interface native de Dolibarr en Multicompany / Multiselect environment filter following Dolibarr native Multicompany interface.
 - Harmonisation du filtre de semaine de la liste avec la fiche via le sélecteur ISO / Harmonized week filter between list and card using the ISO selector.
 - Filtre de semaine en multi-sélection pour combiner plusieurs périodes directement depuis la liste / Multi-select week filter to combine several periods directly from the list.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Description of the module...
 - Affichage des compteurs de zones et de paniers dans la liste des feuilles hebdomadaires.
 - Création rapide d'une feuille d'heures depuis le raccourci "Ajouter" du menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
+- Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
 
 <!--
 ![Screenshot timesheetweek](img/screenshot_timesheetweek.png?raw=true "TimesheetWeek"){imgmd}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Description of the module...
 - Affichage des compteurs de zones et de paniers dans la liste des feuilles hebdomadaires.
 - Création rapide d'une feuille d'heures depuis le raccourci "Ajouter" du menu supérieur.
 - Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
+- Inscription automatique de la configuration Multicompany lors de l'activation et nettoyage lors de la désactivation / Automatic registration of the Multicompany configuration on activation and cleanup on deactivation.
 - Affichage de l'entité dans la liste et la fiche lorsqu'on utilise Multicompany / Display entity information in list and card when using Multicompany.
 
 <!--

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Description of the module...
 - Recalcul automatique des compteurs de zones et de paniers lors de chaque enregistrement.
 - Affichage des compteurs de zones et de paniers dans la liste des feuilles hebdomadaires.
 - Création rapide d'une feuille d'heures depuis le raccourci "Ajouter" du menu supérieur.
+- Compatibilité Multicompany pour partager les feuilles de temps et leur numérotation / Multicompany compatibility to share weekly timesheets and their numbering.
 
 <!--
 ![Screenshot timesheetweek](img/screenshot_timesheetweek.png?raw=true "TimesheetWeek"){imgmd}

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -84,4 +84,108 @@ class ActionsTimesheetweek
 
         return 0;
     }
+
+    /**
+     * Prepare and store multicompany sharing configuration.
+     * Préparer et stocker la configuration de partage multicompany.
+     *
+     * @return void
+     */
+    private function registerMulticompanySharingDefinition()
+    {
+        global $conf, $langs;
+
+        // EN: Safeguard the results container to merge data without overwriting existing hooks.
+        // FR: Sécuriser le conteneur de résultats pour fusionner les données sans écraser les hooks existants.
+        if (!is_array($this->results)) {
+            $this->results = array();
+        }
+
+        // EN: Ensure translations are available for the multicompany labels.
+        // FR: S'assurer que les traductions sont disponibles pour les libellés multicompany.
+        $langs->loadLangs(array('timesheetweek@timesheetweek'));
+
+        // EN: Define the sharing payload describing timesheet and numbering options.
+        // FR: Définir la charge utile de partage décrivant les options de feuille de temps et de numérotation.
+        $sharingKey = 'timesheetweek';
+        $definition = array(
+            $sharingKey => array(
+                'sharingelements' => array(
+                    'timesheetweek' => array(
+                        'type' => 'element',
+                        'icon' => 'calendar-check-o',
+                        'lang' => 'timesheetweek@timesheetweek',
+                        'tooltip' => 'ShareTimesheetWeekTooltip',
+                        'enable' => '! empty($conf->timesheetweek->enabled)',
+                    ),
+                    'timesheetweeknumbering' => array(
+                        'type' => 'object',
+                        'icon' => 'hashtag',
+                        'lang' => 'timesheetweek@timesheetweek',
+                        'tooltip' => 'ShareTimesheetWeekNumberingTooltip',
+                        'mandatory' => 'timesheetweek',
+                        'enable' => '! empty($conf->timesheetweek->enabled)',
+                        'display' => '! empty($conf->global->MULTICOMPANY_TIMESHEETWEEK_SHARING_ENABLED)',
+                        'input' => array(
+                            'global' => array(
+                                'hide' => true,
+                                'del' => true,
+                            ),
+                            'timesheetweek' => array(
+                                'showhide' => true,
+                                'del' => true,
+                            ),
+                        ),
+                    ),
+                ),
+                'sharingmodulename' => array(
+                    'timesheetweek' => 'timesheetweek',
+                    'timesheetweeknumbering' => 'timesheetweek',
+                ),
+            ),
+        );
+
+        // EN: Merge the definition with any pre-existing sharing data exposed by other hooks.
+        // FR: Fusionner la définition avec d'éventuelles données de partage déjà exposées par d'autres hooks.
+        $this->results = array_replace_recursive($this->results, $definition);
+    }
+
+    /**
+     * Provide multicompany sharing options through the dedicated hook.
+     * Fournir les options de partage multicompany via le hook dédié.
+     */
+    public function multicompanyExternalModulesSharing($parameters, &$object, &$action, $hookmanager)
+    {
+        // EN: Register the sharing definition for the multicompany extension.
+        // FR: Enregistrer la définition de partage pour l'extension multicompany.
+        $this->registerMulticompanySharingDefinition();
+
+        return 0;
+    }
+
+    /**
+     * Alias hook to support alternate multicompany triggers.
+     * Hook alias pour supporter des déclencheurs multicompany alternatifs.
+     */
+    public function multicompanyExternalModuleSharing($parameters, &$object, &$action, $hookmanager)
+    {
+        // EN: Delegate to the primary multicompany sharing registration.
+        // FR: Déléguer à l'enregistrement principal du partage multicompany.
+        $this->registerMulticompanySharingDefinition();
+
+        return 0;
+    }
+
+    /**
+     * Additional alias covering broader multicompany sharing requests.
+     * Alias supplémentaire couvrant les requêtes de partage multicompany plus larges.
+     */
+    public function multicompanySharingOptions($parameters, &$object, &$action, $hookmanager)
+    {
+        // EN: Reuse the shared definition to keep behaviour consistent across hooks.
+        // FR: Réutiliser la définition partagée pour conserver un comportement cohérent entre les hooks.
+        $this->registerMulticompanySharingDefinition();
+
+        return 0;
+    }
 }

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -5,6 +5,10 @@
  */
 class ActionsTimesheetweek
 {
+    // EN: Identifier used by the Multicompany sharing payload.
+    // FR: Identifiant utilisé par la charge utile de partage Multicompany.
+    public const MULTICOMPANY_SHARING_ROOT_KEY = 'timesheetweek';
+
     /** @var DoliDB */
     public $db;
 
@@ -86,30 +90,19 @@ class ActionsTimesheetweek
     }
 
     /**
-     * Prepare and store multicompany sharing configuration.
-     * Préparer et stocker la configuration de partage multicompany.
+     * Build the Multicompany sharing payload for the module.
+     * Construire la charge utile de partage Multicompany pour le module.
      *
-     * @return void
+     * @return array
      */
-    private function registerMulticompanySharingDefinition()
+    public static function getMulticompanySharingDefinition()
     {
-        global $conf, $langs;
+        global $conf;
 
-        // EN: Safeguard the results container to merge data without overwriting existing hooks.
-        // FR: Sécuriser le conteneur de résultats pour fusionner les données sans écraser les hooks existants.
-        if (!is_array($this->results)) {
-            $this->results = array();
-        }
-
-        // EN: Ensure translations are available for the multicompany labels.
-        // FR: S'assurer que les traductions sont disponibles pour les libellés multicompany.
-        $langs->loadLangs(array('timesheetweek@timesheetweek'));
-
-        // EN: Define the sharing payload describing timesheet and numbering options.
-        // FR: Définir la charge utile de partage décrivant les options de feuille de temps et de numérotation.
-        $sharingKey = 'timesheetweek';
-        $definition = array(
-            $sharingKey => array(
+        // EN: Prepare the payload describing both the element and numbering sharing options.
+        // FR: Préparer la charge utile décrivant les options de partage des éléments et de la numérotation.
+        return array(
+            self::MULTICOMPANY_SHARING_ROOT_KEY => array(
                 'sharingelements' => array(
                     'timesheetweek' => array(
                         'type' => 'element',
@@ -144,10 +137,31 @@ class ActionsTimesheetweek
                 ),
             ),
         );
+    }
 
-        // EN: Merge the definition with any pre-existing sharing data exposed by other hooks.
-        // FR: Fusionner la définition avec d'éventuelles données de partage déjà exposées par d'autres hooks.
-        $this->results = array_replace_recursive($this->results, $definition);
+    /**
+     * Prepare and store multicompany sharing configuration.
+     * Préparer et stocker la configuration de partage multicompany.
+     *
+     * @return void
+     */
+    private function registerMulticompanySharingDefinition()
+    {
+        global $langs;
+
+        // EN: Safeguard the results container to merge data without overwriting existing hooks.
+        // FR: Sécuriser le conteneur de résultats pour fusionner les données sans écraser les hooks existants.
+        if (!is_array($this->results)) {
+            $this->results = array();
+        }
+
+        // EN: Ensure translations are available for the multicompany labels.
+        // FR: S'assurer que les traductions sont disponibles pour les libellés multicompany.
+        $langs->loadLangs(array('timesheetweek@timesheetweek'));
+
+        // EN: Merge the static definition with any pre-existing sharing data.
+        // FR: Fusionner la définition statique avec les données de partage déjà présentes.
+        $this->results = array_replace_recursive($this->results, self::getMulticompanySharingDefinition());
     }
 
     /**

--- a/class/actions_timesheetweek.class.php
+++ b/class/actions_timesheetweek.class.php
@@ -106,14 +106,18 @@ class ActionsTimesheetweek
                 'sharingelements' => array(
                     'timesheetweek' => array(
                         'type' => 'element',
-                        'icon' => 'calendar-check-o',
+                        'icon' => 'bookcal',
                         'lang' => 'timesheetweek@timesheetweek',
                         'tooltip' => 'ShareTimesheetWeekTooltip',
                         'enable' => '! empty($conf->timesheetweek->enabled)',
                     ),
+                ),
+                // EN: Expose the numbering share inside the dedicated document numbering section.
+                // FR: Exposer le partage de numérotation dans la section dédiée aux numérotations de documents.
+                'sharingdocumentnumbering' => array(
                     'timesheetweeknumbering' => array(
                         'type' => 'object',
-                        'icon' => 'hashtag',
+                        'icon' => 'fa fa-cogs',
                         'lang' => 'timesheetweek@timesheetweek',
                         'tooltip' => 'ShareTimesheetWeekNumberingTooltip',
                         'mandatory' => 'timesheetweek',

--- a/class/timesheetweek.class.php
+++ b/class/timesheetweek.class.php
@@ -1693,14 +1693,18 @@ class TimesheetWeek extends CommonObject
                                 'class' => 'badge badge-status badge-status4',
                         ),
                         self::STATUS_SEALED => array(
+                                // EN: Swap the badge styling with the refused status to improve visual contrast.
+                                // FR: Inverse le style de badge avec le statut refusé pour améliorer le contraste visuel.
                                 'label' => $langs->trans('TimesheetWeekStatusSealed'),
-                                'picto' => 'statut8',
-                                'class' => 'badge badge-status badge-status8',
-                        ),
-                        self::STATUS_REFUSED => array(
-                                'label' => $langs->trans('TimesheetWeekStatusRefused'),
                                 'picto' => 'statut6',
                                 'class' => 'badge badge-status badge-status6',
+                        ),
+                        self::STATUS_REFUSED => array(
+                                // EN: Apply the sealed badge colors to the refused status for clearer differentiation.
+                                // FR: Applique les couleurs du statut scellé au statut refusé pour une meilleure différenciation.
+                                'label' => $langs->trans('TimesheetWeekStatusRefused'),
+                                'picto' => 'statut8',
+                                'class' => 'badge badge-status badge-status8',
                         ),
                 );
 

--- a/class/timesheetweekline.class.php
+++ b/class/timesheetweekline.class.php
@@ -20,6 +20,9 @@ class TimesheetWeekLine extends CommonObjectLine
     public $fk_element = 'fk_timesheet_week';
     public $parent_element = 'timesheetweek';
 
+    // EN: Entity identifier bound to the line.
+    // FR: Identifiant d'entité lié à la ligne.
+    public $entity;
     public $fk_timesheet_week;
     public $fk_task;
     public $day_date;
@@ -41,9 +44,12 @@ class TimesheetWeekLine extends CommonObjectLine
         }
 
         // Build the query for the line / Construit la requête pour la ligne
-        $sql = "SELECT rowid, fk_timesheet_week, fk_task, day_date, hours, zone, meal";
+        $sql = "SELECT rowid, entity, fk_timesheet_week, fk_task, day_date, hours, zone, meal";
         $sql .= " FROM ".MAIN_DB_PREFIX."timesheet_week_line";
         $sql .= " WHERE rowid=".(int) $id;
+        // EN: Respect module entity permissions during line fetch.
+        // FR: Respecte les permissions d'entité du module lors du chargement de la ligne.
+        $sql .= " AND entity IN (".getEntity('timesheetweek').")";
 
         $resql = $this->db->query($sql);
         if (!$resql) {
@@ -60,6 +66,7 @@ class TimesheetWeekLine extends CommonObjectLine
         // Map database values to object / Mappe les valeurs de la base vers l'objet
         $this->id = (int) $obj->rowid;
         $this->rowid = (int) $obj->rowid;
+        $this->entity = (int) $obj->entity;
         $this->fk_timesheet_week = (int) $obj->fk_timesheet_week;
         $this->fk_task = (int) $obj->fk_task;
         $this->day_date = $obj->day_date;
@@ -75,11 +82,34 @@ class TimesheetWeekLine extends CommonObjectLine
      */
     public function save($user)
     {
+        // EN: Resolve the entity from the parent sheet when not provided.
+        // FR: Récupère l'entité depuis la feuille parente lorsqu'elle n'est pas fournie.
+        if (empty($this->entity) && !empty($this->fk_timesheet_week)) {
+            $sqlEntity = "SELECT entity FROM ".MAIN_DB_PREFIX."timesheet_week WHERE rowid=".(int) $this->fk_timesheet_week;
+            $sqlEntity .= " AND entity IN (".getEntity('timesheetweek').")";
+            $resEntity = $this->db->query($sqlEntity);
+            if ($resEntity) {
+                $objEntity = $this->db->fetch_object($resEntity);
+                if ($objEntity) {
+                    $this->entity = (int) $objEntity->entity;
+                }
+            }
+        }
+        if (empty($this->entity)) {
+            global $conf;
+            // EN: Fall back to the current context entity as a last resort.
+            // FR: Revient en dernier recours à l'entité du contexte courant.
+            $this->entity = isset($conf->entity) ? (int) $conf->entity : 1;
+        }
+
         // Vérifie si une ligne existe déjà pour cette tâche et ce jour
         $sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."timesheet_week_line";
         $sql .= " WHERE fk_timesheet_week = ".((int)$this->fk_timesheet_week);
         $sql .= " AND fk_task = ".((int)$this->fk_task);
         $sql .= " AND day_date = '".$this->db->escape($this->day_date)."'";
+        // EN: Keep lookups limited to lines inside allowed entities.
+        // FR: Limite les recherches aux lignes situées dans les entités autorisées.
+        $sql .= " AND entity IN (".getEntity('timesheetweek').")";
 
         $resql = $this->db->query($sql);
         if ($resql && $this->db->num_rows($resql) > 0) {
@@ -90,13 +120,19 @@ class TimesheetWeekLine extends CommonObjectLine
             $sqlu .= " zone = ".((int)$this->zone).",";
             $sqlu .= " meal = ".((int)$this->meal);
             $sqlu .= " WHERE rowid = ".((int)$obj->rowid);
+            // EN: Ensure updates stay within the permitted entity scope.
+            // FR: Assure que les mises à jour restent dans le périmètre d'entité autorisé.
+            $sqlu .= " AND entity IN (".getEntity('timesheetweek').")";
             return $this->db->query($sqlu) ? 1 : -1;
         }
         else {
             // ---- INSERT ----
+            // EN: Persist the entity alongside the usual line fields for consistency.
+            // FR: Enregistre l'entité avec les champs habituels de la ligne pour rester cohérent.
             $sqli = "INSERT INTO ".MAIN_DB_PREFIX."timesheet_week_line(";
-            $sqli .= " fk_timesheet_week, fk_task, day_date, hours, zone, meal)";
+            $sqli .= " entity, fk_timesheet_week, fk_task, day_date, hours, zone, meal)";
             $sqli .= " VALUES(";
+            $sqli .= (int)$this->entity.",";
             $sqli .= (int)$this->fk_timesheet_week.",";
             $sqli .= (int)$this->fk_task.",";
             $sqli .= "'".$this->db->escape($this->day_date)."',";

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -128,6 +128,11 @@ class modTimesheetWeek extends DolibarrModules
                         'hooks' => array(
                                 'data' => array(
                                         'toprightmenu',
+                                        // EN: Register multicompany sharing contexts to expose sharing options.
+                                        // FR: Enregistrer les contextes multicompany pour exposer les options de partage.
+                                        'multicompanyexternalmodulesharing',
+                                        'multicompanyexternalmodules',
+                                        'multicompanysharingoptions',
                                 ),
                                 'entity' => '0',
                         ),

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -674,7 +674,40 @@ class modTimesheetWeek extends DolibarrModules
 			}
 		}
 
-		return $this->_init($sql, $options);
+                // EN: Register Multicompany sharing metadata when the module is enabled.
+                // FR: Enregistrer les métadonnées de partage Multicompany lors de l'activation du module.
+                dol_include_once('/timesheetweek/class/actions_timesheetweek.class.php');
+
+                // EN: Start from the current external module sharing configuration or an empty set.
+                // FR: Partir de la configuration de partage des modules externes actuelle ou d'un ensemble vide.
+                $externalmodule = json_decode((string) ($conf->global->MULTICOMPANY_EXTERNAL_MODULES_SHARING ?? ''), true);
+                if (!is_array($externalmodule)) {
+                        // EN: Guarantee an array structure even when the constant is missing or invalid.
+                        // FR: Garantir une structure de tableau même lorsque la constante est absente ou invalide.
+                        $externalmodule = array();
+                }
+
+                // EN: Initialize the parameters container before filling it with sharing data.
+                // FR: Initialiser le conteneur de paramètres avant de le remplir avec les données de partage.
+                $params = array();
+                if (class_exists('ActionsTimesheetweek')) {
+                        // EN: Reuse the hook helper to expose the sharing parameters to Multicompany.
+                        // FR: Réutiliser l'assistant de hook pour exposer les paramètres de partage à Multicompany.
+                        $params = ActionsTimesheetweek::getMulticompanySharingDefinition();
+                }
+
+                if (!empty($params)) {
+                        // EN: Merge TimesheetWeek definitions with any existing external module configuration.
+                        // FR: Fusionner les définitions TimesheetWeek avec toute configuration de module externe existante.
+                        $externalmodule = array_merge($externalmodule, $params);
+
+                        // EN: Persist the refreshed configuration in the Dolibarr constants table.
+                        // FR: Persister la configuration actualisée dans la table des constantes de Dolibarr.
+                        $jsonformat = json_encode($externalmodule);
+                        dolibarr_set_const($this->db, 'MULTICOMPANY_EXTERNAL_MODULES_SHARING', $jsonformat, 'chaine', 0, '', $conf->entity);
+                }
+
+                return $this->_init($sql, $options);
 	}
 
 	/**
@@ -687,7 +720,37 @@ class modTimesheetWeek extends DolibarrModules
 	 */
 	public function remove($options = '')
 	{
-		$sql = array();
-		return $this->_remove($sql, $options);
-	}
+                // EN: Access the global configuration to manipulate stored constants.
+                // FR: Accéder à la configuration globale pour manipuler les constantes stockées.
+                global $conf;
+
+                // EN: Load the hook helper to clean the sharing definition on deactivation.
+                // FR: Charger l'assistant de hook pour nettoyer la définition de partage à la désactivation.
+                dol_include_once('/timesheetweek/class/actions_timesheetweek.class.php');
+
+                // EN: Decode the current external module sharing configuration safely.
+                // FR: Décoder prudemment la configuration de partage des modules externes actuelle.
+                $externalmodule = json_decode((string) ($conf->global->MULTICOMPANY_EXTERNAL_MODULES_SHARING ?? ''), true);
+                if (!is_array($externalmodule)) {
+                        // EN: Fallback to an empty array when the stored value is not valid JSON.
+                        // FR: Revenir à un tableau vide lorsque la valeur stockée n'est pas un JSON valide.
+                        $externalmodule = array();
+                }
+
+                // EN: Determine the key used to store TimesheetWeek sharing data.
+                // FR: Déterminer la clé utilisée pour stocker les données de partage TimesheetWeek.
+                $sharingKey = class_exists('ActionsTimesheetweek') ? ActionsTimesheetweek::MULTICOMPANY_SHARING_ROOT_KEY : 'timesheetweek';
+
+                // EN: Remove the module definition so Multicompany forgets our sharing options.
+                // FR: Retirer la définition du module pour que Multicompany oublie nos options de partage.
+                unset($externalmodule[$sharingKey]);
+
+                // EN: Persist the cleaned configuration back into Dolibarr constants.
+                // FR: Persister la configuration nettoyée dans les constantes Dolibarr.
+                $jsonformat = json_encode($externalmodule);
+                dolibarr_set_const($this->db, 'MULTICOMPANY_EXTERNAL_MODULES_SHARING', $jsonformat, 'chaine', 0, '', $conf->entity);
+
+                $sql = array();
+                return $this->_remove($sql, $options);
+        }
 }

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -21,6 +21,14 @@ TIMESHEETWEEK_MYPARAM1Tooltip = My param 1 tooltip
 TIMESHEETWEEK_MYPARAM2=My param 2
 TIMESHEETWEEK_MYPARAM2Tooltip=My param 2 tooltip
 
+#
+# Multicompany sharing
+#
+ShareTimesheetWeek = Share weekly timesheets
+ShareTimesheetWeekTooltip = Allow entities to access the same weekly timesheets across the group.
+ShareTimesheetWeekNumbering = Share weekly timesheet numbering
+ShareTimesheetWeekNumberingTooltip = Synchronize numbering sequences for weekly timesheets between entities.
+
 
 #
 # About page

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -29,7 +29,6 @@ ShareTimesheetWeekTooltip = Allow entities to access the same weekly timesheets 
 ShareTimesheetWeekNumbering = Share weekly timesheet numbering
 ShareTimesheetWeekNumberingTooltip = Synchronize numbering sequences for weekly timesheets between entities.
 SelectWeekPlaceholder = -- Select a week --
-SelectWeeksPlaceholder = Select one or more weeks
 
 
 #

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -28,6 +28,7 @@ ShareTimesheetWeek = Share weekly timesheets
 ShareTimesheetWeekTooltip = Allow entities to access the same weekly timesheets across the group.
 ShareTimesheetWeekNumbering = Share weekly timesheet numbering
 ShareTimesheetWeekNumberingTooltip = Synchronize numbering sequences for weekly timesheets between entities.
+SelectWeekPlaceholder = -- Select a week --
 
 
 #

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -24,9 +24,13 @@ TIMESHEETWEEK_MYPARAM2Tooltip=My param 2 tooltip
 #
 # Multicompany sharing
 #
+TIMESHEETWEEKSharing = TimesheetWeek sharing
+TIMESHEETWEEKSharingDescription = Configure Multicompany sharing for weekly timesheets.
 ShareTimesheetWeek = Share weekly timesheets
+ShareTimesheetweek = Share weekly timesheets
 ShareTimesheetWeekTooltip = Allow entities to access the same weekly timesheets across the group.
 ShareTimesheetWeekNumbering = Share weekly timesheet numbering
+ShareTimesheetweeknumbering = Share weekly timesheet numbering
 ShareTimesheetWeekNumberingTooltip = Synchronize numbering sequences for weekly timesheets between entities.
 SelectWeekPlaceholder = -- Select a week --
 

--- a/langs/en_US/timesheetweek.lang
+++ b/langs/en_US/timesheetweek.lang
@@ -29,6 +29,7 @@ ShareTimesheetWeekTooltip = Allow entities to access the same weekly timesheets 
 ShareTimesheetWeekNumbering = Share weekly timesheet numbering
 ShareTimesheetWeekNumberingTooltip = Synchronize numbering sequences for weekly timesheets between entities.
 SelectWeekPlaceholder = -- Select a week --
+SelectWeeksPlaceholder = Select one or more weeks
 
 
 #

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -30,7 +30,6 @@ ShareTimesheetWeekTooltip = Autoriser les entités à accéder aux mêmes feuill
 ShareTimesheetWeekNumbering = Partager la numérotation des feuilles de temps hebdomadaires
 ShareTimesheetWeekNumberingTooltip = Synchroniser les séquences de numérotation des feuilles de temps hebdomadaires entre les entités.
 SelectWeekPlaceholder = -- Sélectionnez une semaine --
-SelectWeeksPlaceholder = Sélectionnez une ou plusieurs semaines
 
 #
 # Page À propos

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -23,6 +23,14 @@ TIMESHEETWEEK_MYPARAM2Tooltip=Info-bulle de mon paramètre 2
 
 
 #
+# Partage multicompany
+#
+ShareTimesheetWeek = Partager les feuilles de temps hebdomadaires
+ShareTimesheetWeekTooltip = Autoriser les entités à accéder aux mêmes feuilles de temps hebdomadaires dans le groupe.
+ShareTimesheetWeekNumbering = Partager la numérotation des feuilles de temps hebdomadaires
+ShareTimesheetWeekNumberingTooltip = Synchroniser les séquences de numérotation des feuilles de temps hebdomadaires entre les entités.
+
+#
 # Page À propos
 #
 About = À propos

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -30,6 +30,7 @@ ShareTimesheetWeekTooltip = Autoriser les entités à accéder aux mêmes feuill
 ShareTimesheetWeekNumbering = Partager la numérotation des feuilles de temps hebdomadaires
 ShareTimesheetWeekNumberingTooltip = Synchroniser les séquences de numérotation des feuilles de temps hebdomadaires entre les entités.
 SelectWeekPlaceholder = -- Sélectionnez une semaine --
+SelectWeeksPlaceholder = Sélectionnez une ou plusieurs semaines
 
 #
 # Page À propos

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -29,6 +29,7 @@ ShareTimesheetWeek = Partager les feuilles de temps hebdomadaires
 ShareTimesheetWeekTooltip = Autoriser les entités à accéder aux mêmes feuilles de temps hebdomadaires dans le groupe.
 ShareTimesheetWeekNumbering = Partager la numérotation des feuilles de temps hebdomadaires
 ShareTimesheetWeekNumberingTooltip = Synchroniser les séquences de numérotation des feuilles de temps hebdomadaires entre les entités.
+SelectWeekPlaceholder = -- Sélectionnez une semaine --
 
 #
 # Page À propos

--- a/langs/fr_FR/timesheetweek.lang
+++ b/langs/fr_FR/timesheetweek.lang
@@ -25,9 +25,13 @@ TIMESHEETWEEK_MYPARAM2Tooltip=Info-bulle de mon paramètre 2
 #
 # Partage multicompany
 #
+TIMESHEETWEEKSharing = Partage TimesheetWeek
+TIMESHEETWEEKSharingDescription = Configurer le partage Multicompany des feuilles de temps hebdomadaires.
 ShareTimesheetWeek = Partager les feuilles de temps hebdomadaires
+ShareTimesheetweek = Partager les feuilles de temps hebdomadaires
 ShareTimesheetWeekTooltip = Autoriser les entités à accéder aux mêmes feuilles de temps hebdomadaires dans le groupe.
 ShareTimesheetWeekNumbering = Partager la numérotation des feuilles de temps hebdomadaires
+ShareTimesheetweeknumbering = Partager la numérotation des feuilles de temps hebdomadaires
 ShareTimesheetWeekNumberingTooltip = Synchroniser les séquences de numérotation des feuilles de temps hebdomadaires entre les entités.
 SelectWeekPlaceholder = -- Sélectionnez une semaine --
 

--- a/lib/timesheetweek.lib.php
+++ b/lib/timesheetweek.lib.php
@@ -328,79 +328,91 @@ function getWeekSelectorDolibarr($form, $htmlname, $selected = 0, $year = 0, $in
 {
         global $langs;
 
-        // EN: Prepare the selected values for either single or multiple mode.
-        // FR: Prépare les valeurs sélectionnées pour le mode simple ou multiple.
-        $selectedYear = 0;
-        $selectedWeek = 0;
-        $selectedValues = array();
-
         if ($multiple) {
-                // EN: Normalise the selection list when multiple weeks can be chosen.
-                // FR: Normalise la liste de sélection lorsque plusieurs semaines peuvent être choisies.
+                // EN: Normalise the ISO year-week values and reuse Dolibarr's native multi-select layout.
+                // FR: Normalise les valeurs ISO année-semaine et réutilise la présentation multi-sélection native de Dolibarr.
                 if (!is_array($selected)) {
                         $selected = $selected !== '' ? array($selected) : array();
                 }
 
+                $selectedValues = array();
                 foreach ($selected as $candidate) {
                         if (is_string($candidate) && preg_match('/^(\d{4})-W(\d{2})$/', $candidate, $matches)) {
-                                $isoKey = $matches[1].'-W'.$matches[2];
-                                $selectedValues[$isoKey] = true;
+                                $selectedValues[$matches[1].'-W'.$matches[2]] = true;
                         }
                 }
 
                 if (empty($year)) {
-                        // EN: Use the current ISO year to populate the selector when no year is specified.
-                        // FR: Utilise l'année ISO courante pour alimenter le sélecteur lorsqu'aucune année n'est précisée.
+                        // EN: Default to the current ISO year when no context year is supplied.
+                        // FR: Utilise l'année ISO courante lorsqu'aucune année de contexte n'est fournie.
                         $year = (int) date('o');
                 }
+
+                $options = array();
+                for ($week = 1; $week <= 53; $week++) {
+                        $dto = new DateTime();
+                        $dto->setISODate($year, $week);
+                        $start = dol_print_date($dto->getTimestamp(), 'day');
+                        $dto->modify('+6 days');
+                        $end = dol_print_date($dto->getTimestamp(), 'day');
+
+                        $isoKey = $year.'-W'.str_pad((string) $week, 2, '0', STR_PAD_LEFT);
+                        $options[$isoKey] = $langs->trans('Week').' '.$week.' ('.$start.' → '.$end.')';
+                }
+
+                return $form->multiselectarray(
+                        $htmlname,
+                        $options,
+                        array_keys($selectedValues),
+                        0,
+                        0,
+                        'minwidth150 maxwidth200',
+                        0,
+                        0,
+                        '',
+                        '',
+                        '',
+                        '',
+                        '',
+                        1
+                );
+        }
+
+        // EN: Prepare the selected week and year for the single-choice selector.
+        // FR: Prépare la semaine et l'année sélectionnées pour le sélecteur mono-choix.
+        $selectedYear = 0;
+        $selectedWeek = 0;
+
+        if (is_string($selected) && preg_match('/^(\d{4})-W(\d{2})$/', $selected, $matches)) {
+                $selectedYear = (int) $matches[1];
+                $selectedWeek = (int) $matches[2];
         } else {
-                // EN: Accept either an integer week number or an ISO year-week string (YYYY-Www).
-                // FR: Accepte soit un numéro de semaine entier, soit une chaîne ISO année-semaine (AAAA-Sww).
-                if (is_string($selected) && preg_match('/^(\d{4})-W(\d{2})$/', $selected, $matches)) {
-                        $selectedYear = (int) $matches[1];
-                        $selectedWeek = (int) $matches[2];
-                } else {
-                        $selectedWeek = (int) $selected;
-                }
-
-                if (empty($year)) {
-                        // EN: Prefer the parsed year when available, otherwise default to the current ISO year.
-                        // FR: Privilégie l'année analysée si disponible, sinon utilise l'année ISO courante.
-                        $year = $selectedYear > 0 ? $selectedYear : (int) date('o');
-                }
-
-                if ($selectedYear <= 0) {
-                        // EN: Align the selection year with the generated year when none was provided explicitly.
-                        // FR: Aligne l'année sélectionnée avec l'année générée lorsqu'aucune n'est fournie explicitement.
-                        $selectedYear = $year;
-                }
-
-                if ($selectedWeek <= 0) {
-                        // EN: Default to the current week unless an empty placeholder is requested.
-                        // FR: Par défaut utilise la semaine courante sauf si un choix vide est demandé.
-                        $selectedWeek = $includeEmpty ? 0 : (int) date('W');
-                }
+                $selectedWeek = (int) $selected;
         }
 
-        $nameAttribute = $htmlname;
-        if ($multiple && substr($htmlname, -2) !== '[]') {
-                // EN: Append [] so PHP receives the selected weeks as an array.
-                // FR: Ajoute [] pour que PHP reçoive les semaines sélectionnées sous forme de tableau.
-                $nameAttribute .= '[]';
+        if (empty($year)) {
+                // EN: Use the parsed year when possible, otherwise rely on the current ISO year.
+                // FR: Utilise l'année extraite lorsque possible, sinon se base sur l'année ISO courante.
+                $year = $selectedYear > 0 ? $selectedYear : (int) date('o');
         }
 
-        $extraAttributes = '';
-        if ($multiple) {
-                // EN: Expose Select2 metadata for a richer multi-select experience.
-                // FR: Expose des métadonnées Select2 pour une expérience multi-sélection enrichie.
-                $extraAttributes = ' multiple data-placeholder="'.dol_escape_htmltag($langs->trans('SelectWeeksPlaceholder')).'"';
+        if ($selectedYear <= 0) {
+                // EN: Align the selected year with the rendered year when none is provided explicitly.
+                // FR: Aligne l'année sélectionnée avec l'année affichée lorsqu'aucune n'est fournie explicitement.
+                $selectedYear = $year;
         }
 
-        $out = '<select class="flat minwidth200'.($multiple ? ' select2' : '').'" name="'.$nameAttribute.'" id="'.$htmlname.'"'.$extraAttributes.'>';
+        if ($selectedWeek <= 0) {
+                // EN: Default to the current week except when an empty option must be shown.
+                // FR: Utilise la semaine courante sauf si une option vide doit être proposée.
+                $selectedWeek = $includeEmpty ? 0 : (int) date('W');
+        }
 
-        if ($includeEmpty && !$multiple) {
+        $out = '<select class="flat minwidth200" name="'.$htmlname.'" id="'.$htmlname.'">';
+
+        if ($includeEmpty) {
                 // EN: Offer an empty option so list filters can be cleared.
-                // FR: Offre une option vide pour permettre de réinitialiser les filtres de liste.
+                // FR: Ajoute une option vide pour permettre de réinitialiser les filtres de liste.
                 $out .= '<option value=""'.($selectedWeek === 0 ? ' selected' : '').'>'.dol_escape_htmltag($langs->trans('SelectWeekPlaceholder')).'</option>';
         }
 
@@ -411,16 +423,9 @@ function getWeekSelectorDolibarr($form, $htmlname, $selected = 0, $year = 0, $in
                 $dto->modify('+6 days');
                 $end = dol_print_date($dto->getTimestamp(), 'day');
 
-                $label = $langs->trans("Week").' '.$week.' ('.$start.' → '.$end.')';
+                $label = $langs->trans('Week').' '.$week.' ('.$start.' → '.$end.')';
                 $val = $year.'-W'.str_pad((string) $week, 2, '0', STR_PAD_LEFT);
-
-                if ($multiple) {
-                        // EN: Mark each ISO entry as selected when building the multi-choice selector.
-                        // FR: Marque chaque entrée ISO comme sélectionnée lors de la construction du sélecteur multi-choix.
-                        $isselected = isset($selectedValues[$val]);
-                } else {
-                        $isselected = ($selectedWeek === $week && $selectedYear === $year);
-                }
+                $isselected = ($selectedWeek === $week && $selectedYear === $year);
                 $out .= '<option value="'.$val.'"'.($isselected ? ' selected' : '').'>'.$label.'</option>';
         }
 

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -816,7 +816,15 @@ JS;
         if (!empty($object->id)) {
                 $morehtmlstatus = $object->getLibStatut(5);
         }
-        dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', '', '', $morehtmlright, '', $morehtmlstatus);
+
+        $morehtmlref = '';
+        if (!empty($conf->multicompany->enabled)) {
+                // EN: Append the entity identifier inside the banner when Multicompany is enabled.
+                // FR: Ajoute l'identifiant d'entité dans la bannière lorsque Multicompany est activé.
+                $morehtmlref .= '<br>'.$langs->trans('Entity').': '.dol_escape_htmltag((string) $object->entity);
+        }
+
+        dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', '', $morehtmlref, $morehtmlright, '', $morehtmlstatus);
         print timesheetweekRenderStatusBadgeCleanup();
 
 	// Confirm modals

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -832,10 +832,31 @@ JS;
         }
 
         $morehtmlref = '';
-        if (!empty($conf->multicompany->enabled)) {
-                // EN: Append the entity identifier inside the banner when Multicompany is enabled.
-                // FR: Ajoute l'identifiant d'entité dans la bannière lorsque Multicompany est activé.
-                $morehtmlref .= '<br>'.$langs->trans('Entity').': '.dol_escape_htmltag((string) $object->entity);
+        if (!empty($conf->multicompany->enabled) && (int) $object->entity !== (int) $conf->entity) {
+                // EN: Fetch the entity label to display the native Multicompany badge below the reference.
+                // FR: Récupère le libellé de l'entité pour afficher le badge Multicompany natif sous la référence.
+                $entityName = '';
+                $entityId = (int) $object->entity;
+                if ($entityId > 0) {
+                        $sqlEntity = 'SELECT label FROM '.MAIN_DB_PREFIX."entity WHERE rowid = ".$entityId;
+                        $resEntity = $db->query($sqlEntity);
+                        if ($resEntity) {
+                                $entityRow = $db->fetch_object($resEntity);
+                                if ($entityRow) {
+                                        $entityName = trim((string) $entityRow->label);
+                                }
+                                $db->free($resEntity);
+                        }
+                        if ($entityName === '') {
+                                // EN: Fall back to a generic label when the entity dictionary is empty.
+                                // FR: Revient à un libellé générique lorsque le dictionnaire d'entités est vide.
+                                $entityName = $langs->trans('Entity').' #'.$entityId;
+                        }
+                        $entityBadge = '<div class="refidno multicompany-entity-card-container"><span class="fa fa-globe"></span><span class="multiselect-selected-title-text">'.dol_escape_htmltag($entityName).'</span></div>';
+                        // EN: Inject the entity badge underneath the reference to mimic Dolibarr's native layout.
+                        // FR: Insère le badge d'entité sous la référence pour reproduire la mise en page native de Dolibarr.
+                        $morehtmlref .= '<br>'.$entityBadge;
+                }
         }
 
         dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', '', $morehtmlref, $morehtmlright, '', $morehtmlstatus);

--- a/timesheetweek_list.php
+++ b/timesheetweek_list.php
@@ -177,6 +177,9 @@ $sql .= " u.rowid as uid, u.firstname, u.lastname, u.login";
 $sql .= " FROM ".MAIN_DB_PREFIX."timesheet_week as t";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid = t.fk_user";
 $sql .= " WHERE 1=1";
+// EN: Restrict the listing to the entities allowed for the timesheet module.
+// FR: Restreint la liste aux entités autorisées pour le module de feuilles de temps.
+$sql .= " AND t.entity IN (".getEntity('timesheetweek').")";
 if ($search_ref !== '')     $sql .= natural_search('t.ref', $search_ref);
 if ($search_user > 0)       $sql .= " AND t.fk_user = ".((int)$search_user);
 if ($search_year > 0)       $sql .= " AND t.year = ".((int)$search_year);


### PR DESCRIPTION
## Résumé
- ajoute les définitions de partage Multicompany pour les feuilles de temps et leur numérotation
- enregistre les contextes de hook Multicompany et les traductions associées
- documente la compatibilité Multicompany dans le README et le ChangeLog

## Tests
- `php -l class/actions_timesheetweek.class.php`


------
https://chatgpt.com/codex/tasks/task_e_68e6247286f4832e88c856e362a24660