### PR TITLE
Add fk_user_seal and date_seal columns to llx_timesheet_week

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # CHANGELOG MODULE TIMESHEETWEEK FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
+## 1.7.1 (04/02/2026)
+- Ajoute les colonnes fk_user_seal et date_seal sur llx_timesheet_week avec les index associés. / Adds fk_user_seal and date_seal columns on llx_timesheet_week with the related indexes.
+
 ## 1.7.0 (14/01/2026)
 - Ajoute un scellement automatique des feuilles approuvées après un délai configurable via une tâche planifiée Dolibarr native. / Adds automatic sealing of approved timesheets after a configurable delay through a native Dolibarr scheduled task.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # CHANGELOG MODULE TIMESHEETWEEK FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
+## 1.7.2 (05/02/2026)
+- Met à jour les métadonnées de scellement (fk_user_seal, date_seal) lors du scellement manuel. / Updates seal metadata (fk_user_seal, date_seal) during manual sealing.
+
 ## 1.7.1 (04/02/2026)
 - Ajoute les colonnes fk_user_seal et date_seal sur llx_timesheet_week avec les index associés. / Adds fk_user_seal and date_seal columns on llx_timesheet_week with the related indexes.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # CHANGELOG MODULE TIMESHEETWEEK FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
+## 1.7.3 (05/02/2026)
+- Met à jour les métadonnées de scellement (fk_user_seal, date_seal) lors des scellements manuels et automatiques. / Updates seal metadata (fk_user_seal, date_seal) during manual and automatic sealing.
+
 ## 1.7.2 (05/02/2026)
 - Met à jour les métadonnées de scellement (fk_user_seal, date_seal) lors du scellement manuel. / Updates seal metadata (fk_user_seal, date_seal) during manual sealing.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # CHANGELOG MODULE TIMESHEETWEEK FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
+## 1.7.4 (05/02/2026)
+- Met à jour les métadonnées de scellement (fk_user_seal, date_seal) lors du scellement via l'action de masse. / Updates seal metadata (fk_user_seal, date_seal) during the mass action sealing.
+
 ## 1.7.3 (05/02/2026)
 - Met à jour les métadonnées de scellement (fk_user_seal, date_seal) lors des scellements manuels et automatiques. / Updates seal metadata (fk_user_seal, date_seal) during manual and automatic sealing.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ TimesheetWeek ajoute une gestion hebdomadaire des feuilles de temps fidèle à l
 - Saisie dédiée pour les salariés en forfait jour grâce à des sélecteurs Journée/Matin/Après-midi convertissant automatiquement les heures.
 - Rappel hebdomadaire automatique par email configurable (activation, jour, heure, modèle) avec tâche planifiée dédiée et bouton d'envoi de test administrateur.
 - Scellement automatique des feuilles approuvées après un délai configurable via une tâche planifiée Dolibarr native.
+- Stocke l'utilisateur et la date de scellement dans des colonnes dédiées pour faciliter le suivi.
 - Affichage des compteurs dans la liste hebdomadaire et ajout du libellé « Zone » sur chaque sélecteur quotidien pour clarifier la saisie.
 - Capture les heures au contrat au moment de la soumission pour figer le calcul des heures supplémentaires et les PDF, même si le contrat salarié évolue ensuite.
 - Ligne de total en bas de la liste hebdomadaire pour additionner heures, zones, paniers et afficher la colonne de date de validation.
@@ -57,6 +58,7 @@ TimesheetWeek delivers weekly timesheet management that follows Dolibarr design 
 - Dedicated input for daily rate employees with Full day/Morning/Afternoon selectors that automatically convert hours.
 - Configurable automatic weekly email reminder (enablement, weekday, time, template) with a dedicated scheduled task and admin test send button.
 - Automatic sealing of approved timesheets after a configurable delay through a native Dolibarr scheduled task.
+- Stores seal user and seal date in dedicated columns for easier tracking.
 - Counter display inside the weekly list plus a « Zone » caption on each daily selector for better input guidance.
 - Snapshots contract hours at submission so overtime calculations and PDFs stay aligned even if the employee contract changes later.
 - Total row at the bottom of the weekly list to sum hours, zones, meals and expose the validation date column.

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -112,7 +112,7 @@ class modTimesheetWeek extends DolibarrModules
 		}
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated', 'experimental_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.7.0';
+		$this->version = '1.7.1';
     
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = 'https://moduleversion.lesmetiersdubatiment.fr/ver.php?m=timesheetweek';

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -112,7 +112,7 @@ class modTimesheetWeek extends DolibarrModules
 		}
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated', 'experimental_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.7.2';
+		$this->version = '1.7.3';
     
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = 'https://moduleversion.lesmetiersdubatiment.fr/ver.php?m=timesheetweek';

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -112,7 +112,7 @@ class modTimesheetWeek extends DolibarrModules
 		}
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated', 'experimental_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.7.3';
+		$this->version = '1.7.4';
     
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = 'https://moduleversion.lesmetiersdubatiment.fr/ver.php?m=timesheetweek';

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -112,7 +112,7 @@ class modTimesheetWeek extends DolibarrModules
 		}
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated', 'experimental_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.7.1';
+		$this->version = '1.7.2';
     
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = 'https://moduleversion.lesmetiersdubatiment.fr/ver.php?m=timesheetweek';

--- a/sql/llx_timesheet_week.sql
+++ b/sql/llx_timesheet_week.sql
@@ -13,6 +13,8 @@ CREATE TABLE IF NOT EXISTS llx_timesheet_week (
 	date_creation DATETIME DEFAULT CURRENT_TIMESTAMP,
 	date_validation DATETIME DEFAULT NULL,
 	fk_user_valid INT DEFAULT NULL,
+	fk_user_seal INT DEFAULT NULL,
+	date_seal DATETIME DEFAULT NULL,
 	total_hours DOUBLE(24,8) NOT NULL DEFAULT 0,
 	overtime_hours DOUBLE(24,8) NOT NULL DEFAULT 0,
 	contract DOUBLE(24,8) DEFAULT NULL,
@@ -32,7 +34,9 @@ CREATE TABLE IF NOT EXISTS llx_timesheet_week (
 	KEY idx_timesheet_week_entity (entity),
 	KEY idx_timesheet_week_user (fk_user),
 	KEY idx_timesheet_week_user_valid (fk_user_valid),
+	KEY idx_timesheet_week_fk_user_seal (fk_user_seal),
 	KEY idx_timesheet_week_yearweek (year, week),
+	KEY idx_timesheet_week_date_seal (date_seal),
 
 	CONSTRAINT fk_timesheet_week_user
 		FOREIGN KEY (fk_user) REFERENCES llx_user (rowid),

--- a/sql/update_all.sql
+++ b/sql/update_all.sql
@@ -31,3 +31,71 @@ SET @tsw_add_contract := IF(
 PREPARE tsw_contract_stmt FROM @tsw_add_contract;
 EXECUTE tsw_contract_stmt;
 DEALLOCATE PREPARE tsw_contract_stmt;
+
+-- EN: Add the seal user column to existing tables when missing.
+SET @tsw_has_fk_user_seal := (
+	SELECT COUNT(*)
+	FROM information_schema.COLUMNS
+	WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'llx_timesheet_week'
+		AND COLUMN_NAME = 'fk_user_seal'
+);
+SET @tsw_add_fk_user_seal := IF(
+	@tsw_has_fk_user_seal = 0,
+	'ALTER TABLE llx_timesheet_week ADD COLUMN fk_user_seal INT DEFAULT NULL AFTER fk_user_valid',
+	'SELECT 1'
+);
+PREPARE tsw_fk_user_seal_stmt FROM @tsw_add_fk_user_seal;
+EXECUTE tsw_fk_user_seal_stmt;
+DEALLOCATE PREPARE tsw_fk_user_seal_stmt;
+
+-- EN: Add the seal date column to existing tables when missing.
+SET @tsw_has_date_seal := (
+	SELECT COUNT(*)
+	FROM information_schema.COLUMNS
+	WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'llx_timesheet_week'
+		AND COLUMN_NAME = 'date_seal'
+);
+SET @tsw_add_date_seal := IF(
+	@tsw_has_date_seal = 0,
+	'ALTER TABLE llx_timesheet_week ADD COLUMN date_seal DATETIME DEFAULT NULL AFTER fk_user_seal',
+	'SELECT 1'
+);
+PREPARE tsw_date_seal_stmt FROM @tsw_add_date_seal;
+EXECUTE tsw_date_seal_stmt;
+DEALLOCATE PREPARE tsw_date_seal_stmt;
+
+-- EN: Add index on seal user when missing.
+SET @tsw_has_idx_fk_user_seal := (
+	SELECT COUNT(*)
+	FROM information_schema.STATISTICS
+	WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'llx_timesheet_week'
+		AND INDEX_NAME = 'idx_timesheet_week_fk_user_seal'
+);
+SET @tsw_add_idx_fk_user_seal := IF(
+	@tsw_has_idx_fk_user_seal = 0,
+	'ALTER TABLE llx_timesheet_week ADD INDEX idx_timesheet_week_fk_user_seal (fk_user_seal)',
+	'SELECT 1'
+);
+PREPARE tsw_idx_fk_user_seal_stmt FROM @tsw_add_idx_fk_user_seal;
+EXECUTE tsw_idx_fk_user_seal_stmt;
+DEALLOCATE PREPARE tsw_idx_fk_user_seal_stmt;
+
+-- EN: Add index on seal date when missing.
+SET @tsw_has_idx_date_seal := (
+	SELECT COUNT(*)
+	FROM information_schema.STATISTICS
+	WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'llx_timesheet_week'
+		AND INDEX_NAME = 'idx_timesheet_week_date_seal'
+);
+SET @tsw_add_idx_date_seal := IF(
+	@tsw_has_idx_date_seal = 0,
+	'ALTER TABLE llx_timesheet_week ADD INDEX idx_timesheet_week_date_seal (date_seal)',
+	'SELECT 1'
+);
+PREPARE tsw_idx_date_seal_stmt FROM @tsw_add_idx_date_seal;
+EXECUTE tsw_idx_date_seal_stmt;
+DEALLOCATE PREPARE tsw_idx_date_seal_stmt;

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -811,18 +811,6 @@ if ($action === 'seal' && $id > 0) {
 
 		$res = $object->seal($user, 'manual');
 		if ($res > 0) {
-				// EN: Store seal metadata for the manual action.
-				// FR : Stocke les métadonnées de scellement pour l'action manuelle.
-				$sqlSealMetadata = "UPDATE ".MAIN_DB_PREFIX."timesheet_week SET";
-				$sqlSealMetadata .= " fk_user_seal=".(int) $user->id;
-				$sqlSealMetadata .= ", date_seal='".$db->idate(dol_now())."'";
-				$sqlSealMetadata .= " WHERE rowid=".(int) $object->id;
-				$sqlSealMetadata .= " AND entity IN (".getEntity('timesheetweek').")";
-				if (!$db->query($sqlSealMetadata)) {
-						// EN: Keep the sheet sealed even if the metadata update fails.
-						// FR : Conserver la feuille scellée même si la mise à jour des métadonnées échoue.
-						dol_syslog('TimesheetWeek seal metadata update failed: '.$db->lasterror(), LOG_WARNING);
-				}
 				setEventMessages($langs->trans('TimesheetSealed'), null, 'mesgs');
 		} else {
 				$errmsg = tw_translate_error($object->error, $langs);

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -811,6 +811,18 @@ if ($action === 'seal' && $id > 0) {
 
 		$res = $object->seal($user, 'manual');
 		if ($res > 0) {
+				// EN: Store seal metadata for the manual action.
+				// FR : Stocke les métadonnées de scellement pour l'action manuelle.
+				$sqlSealMetadata = "UPDATE ".MAIN_DB_PREFIX."timesheet_week SET";
+				$sqlSealMetadata .= " fk_user_seal=".(int) $user->id;
+				$sqlSealMetadata .= ", date_seal='".$db->idate(dol_now())."'";
+				$sqlSealMetadata .= " WHERE rowid=".(int) $object->id;
+				$sqlSealMetadata .= " AND entity IN (".getEntity('timesheetweek').")";
+				if (!$db->query($sqlSealMetadata)) {
+						// EN: Keep the sheet sealed even if the metadata update fails.
+						// FR : Conserver la feuille scellée même si la mise à jour des métadonnées échoue.
+						dol_syslog('TimesheetWeek seal metadata update failed: '.$db->lasterror(), LOG_WARNING);
+				}
 				setEventMessages($langs->trans('TimesheetSealed'), null, 'mesgs');
 		} else {
 				$errmsg = tw_translate_error($object->error, $langs);


### PR DESCRIPTION
### Motivation
- Ajouter le traçage du scellement des feuilles (utilisateur et date) sur la table `llx_timesheet_week` pour supporter la fonctionnalité de scellement automatique et le suivi administratif.
- Garantir une montée de version sûre et rejouable sur des instances existantes en rendant les modifications de schéma idempotentes et compatibles MySQL/MariaDB.

### Description
- Ajout des colonnes `fk_user_seal INT DEFAULT NULL` et `date_seal DATETIME DEFAULT NULL` et de leurs index dans le script d'installation `sql/llx_timesheet_week.sql` (index `idx_timesheet_week_fk_user_seal` et `idx_timesheet_week_date_seal`).
- Ajout d'un script d'upgrade idempotent dans `sql/update_all.sql` qui teste l'existence des colonnes/index via `information_schema` et exécute des `ALTER TABLE` conditionnels (prépare/execute) pour créer les colonnes et index si manquants, sans échouer si déjà présents.
- Bump de la version du module dans `core/modules/modTimesheetWeek.class.php` (`1.7.0` -> `1.7.1`).
- Mise à jour documentaire : `ChangeLog.md` et `README.md` pour mentionner l'ajout des colonnes de scellement (fr_FR / en_US descriptions déjà présentes dans les fichiers modifiés).

### Testing
- Aucun test automatisé exécuté pour cette modification (aucune suite de tests lancée via CI/local).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697922fc6d0c832e8bb4cab649d95846)