### PR TITLE
Exclure les forfaits jour de la justification des heures supplémentaires

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # CHANGELOG MODULE TIMESHEETWEEK FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
+## 1.8.3 (29/06/2026)
+- Exclut les feuilles des salariés au forfait jour de la demande de justification des heures supplémentaires lors de l'approbation, tout en conservant le contrôle pour les salariés horaires. / Excludes daily-rate employees' timesheets from overtime justification during approval while keeping the check for hourly employees.
+
 ## 1.8.2 (08/06/2026)
 - Sécurise le rappel hebdomadaire contre les doubles envois en environnement Multicompany avec verrou MySQL, déduplication globale par email et replanification après traitement. / Secures the weekly reminder against duplicate sends in Multicompany environments with a MySQL lock, global email deduplication and rescheduling after processing.
 

--- a/core/modules/modTimesheetWeek.class.php
+++ b/core/modules/modTimesheetWeek.class.php
@@ -112,7 +112,7 @@ class modTimesheetWeek extends DolibarrModules
 		}
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated', 'experimental_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.8.2';
+		$this->version = '1.8.3';
     
 		// Url to the file with your last numberversion of this module
 		$this->url_last_version = 'https://moduleversion.lesmetiersdubatiment.fr/ver.php?m=timesheetweek';

--- a/timesheetweek_card.php
+++ b/timesheetweek_card.php
@@ -171,6 +171,27 @@ function tw_get_employee_with_daily_rate(DoliDB $db, $userId)
 }
 
 /**
+* EN: Tell if overtime approval requires a justification for this timesheet.
+* FR: Indique si l'approbation des heures supplémentaires nécessite une justification pour cette feuille.
+*
+* @param DoliDB         $db     Database handler / Gestionnaire de base de données
+* @param TimesheetWeek  $object Timesheet object / Objet feuille d'heures
+* @return bool                  True when a justification is required / Vrai si une justification est requise
+*/
+function tw_requires_overtime_motif(DoliDB $db, TimesheetWeek $object)
+{
+	$employeeInfoDaily = tw_get_employee_with_daily_rate($db, $object->fk_user);
+	if ($employeeInfoDaily['user'] instanceof User && !empty($employeeInfoDaily['is_daily_rate'])) {
+		return false;
+	}
+
+	$overtimeRequireMotif = getDolGlobalInt('TIMESHEETWEEK_OVERTIME_MOTIF_REQUIRED', 1);
+	$overtimeThresholdHours = tw_hhmm_to_hours(getDolGlobalString('TIMESHEETWEEK_OVERTIME_MOTIF_THRESHOLD', '00:00'));
+
+	return !empty($overtimeRequireMotif) && ((float) $object->overtime_hours >= (float) $overtimeThresholdHours);
+}
+
+/**
 * EN: Retrieve the list of activated PDF models for the module with entity scoping.
 * FR: Récupère la liste des modèles PDF activés pour le module en respectant l'entité.
 *
@@ -967,10 +988,7 @@ if ($action === 'confirm_validate' && $confirm === 'yes' && $id > 0) {
 		$object->context['actioncode'] = 'TIMESHEETWEEK_APPROVE';
 		$object->context['timesheetweek_card_action'] = 'confirm_validate';
 
-		$overtimeRequireMotif = getDolGlobalInt('TIMESHEETWEEK_OVERTIME_MOTIF_REQUIRED', 1);
-		$overtimeThresholdHours = tw_hhmm_to_hours(getDolGlobalString('TIMESHEETWEEK_OVERTIME_MOTIF_THRESHOLD', '00:00'));
-		$requiresMotif = (!empty($overtimeRequireMotif) && ((float) $object->overtime_hours >= (float) $overtimeThresholdHours));
-		if ($requiresMotif && $motif === '') {
+		if (tw_requires_overtime_motif($db, $object) && $motif === '') {
 			setEventMessages($langs->trans('TimesheetWeekMotifOvertimeRequired'), null, 'errors');
 			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id."&action=ask_validate");
 			exit;
@@ -1415,9 +1433,7 @@ JS;
 		if ($action === 'ask_validate') {
 			$formquestion = array();
 			$confirmMessage = $langs->trans('ConfirmValidate');
-			$overtimeRequireMotif = getDolGlobalInt('TIMESHEETWEEK_OVERTIME_MOTIF_REQUIRED', 1);
-			$overtimeThresholdHours = tw_hhmm_to_hours(getDolGlobalString('TIMESHEETWEEK_OVERTIME_MOTIF_THRESHOLD', '00:00'));
-			if (!empty($overtimeRequireMotif) && ((float) $object->overtime_hours >= (float) $overtimeThresholdHours)) {
+			if (tw_requires_overtime_motif($db, $object)) {
 				$formquestion[] = array(
 					'label' => '',
 					'type' => 'other',


### PR DESCRIPTION
Cette PR ajuste le flux d’approbation des feuilles d’heures pour ne plus demander de justification d’heures supplémentaires lorsque le salarié est au forfait jour.
Changements principaux :
Ajout du helper tw_requires_overtime_motif() pour centraliser la règle de justification.
Exclusion des utilisateurs avec l’extrafield options_lmdb_daily_rate.
Réutilisation de cette règle dans la modale de confirmation et dans le contrôle serveur.
Mise à jour du descripteur module en 1.8.3.
Ajout de l’entrée 1.8.3 dans ChangeLog.md.